### PR TITLE
Delete IDs in gruop and user creation in Dockerfiles

### DIFF
--- a/monero/Dockerfile
+++ b/monero/Dockerfile
@@ -41,8 +41,8 @@ RUN apt-get update -q -y --no-install-recommends && \
     rm -rf /var/lib/apt
 
 
-RUN groupadd -r monero -g 1000 && \
-    adduser --uid 1000 --gid 1000 --system --disabled-password monero && \
+RUN groupadd -r monero && \
+    adduser --system --disabled-password --ingroup monero monero && \
 	mkdir -p /home/monero/.bitmonero && \
 	chown -R monero:monero /home/monero/.bitmonero
 

--- a/monero/Dockerfile
+++ b/monero/Dockerfile
@@ -16,7 +16,8 @@ RUN set -e && \
         git \
         libtool \
         pkg-config \
-        gperf
+        gperf \
+        rm -rf /var/lib/apt
 
 
 WORKDIR /src

--- a/p2pool/Dockerfile
+++ b/p2pool/Dockerfile
@@ -36,8 +36,8 @@ RUN apk add --no-cache \
     libuv \ 
     libzmq
 
-RUN addgroup -S p2pool -g 1000 && \
-    adduser -S -u 1000 -G p2pool -s /sbin/nologin -g "p2pool user" p2pool 
+RUN addgroup -S p2pool && \
+    adduser -S -G p2pool -s /sbin/nologin -g "p2pool user" p2pool 
     
 RUN mkdir -p /home/p2pool/.p2pool && \
     chown p2pool.p2pool /home/p2pool /home/p2pool/.p2pool

--- a/xmrig-p2pool/Dockerfile
+++ b/xmrig-p2pool/Dockerfile
@@ -33,8 +33,8 @@ RUN apk add --no-cache \
     libressl \
     hwloc-dev
 
-RUN addgroup -S xmrig -g 1000 && \
-    adduser -S -u 1000 -G xmrig -s /sbin/nologin -g "xmrig user" xmrig  
+RUN addgroup -S xmrig && \
+    adduser -S -G xmrig -s /sbin/nologin -g "xmrig user" xmrig  
 USER xmrig
 
 COPY --from=builder --chown=xmrig:xmrig /usr/src/xmrig/build/xmrig /usr/local/bin/xmrig

--- a/xmrig/Dockerfile
+++ b/xmrig/Dockerfile
@@ -32,8 +32,8 @@ RUN apk update && apk add --no-cache \
     libressl \
     hwloc-dev
 
-RUN addgroup -S xmrig -g 1000 && \
-    adduser -S -u 1000 -G xmrig -s /sbin/nologin -g "xmrig user" xmrig  
+RUN addgroup -S xmrig && \
+    adduser -S -G xmrig -s /sbin/nologin -g "xmrig user" xmrig  
 USER xmrig
 
 WORKDIR /xmr


### PR DESCRIPTION
- Improve portability: Specific IDs can cause conflicts in different environments like Openshift
- Increases security: Avoids exposing potentially sensitive information about the structure of users in our system.
- Simplifies maintenance: Reduces the need to manually manage user and group IDs between systems
- Using fixed IDs could lead to privilege escalation if these IDs match privileged users on the host.
